### PR TITLE
Shorten long value intelligent tree

### DIFF
--- a/example/example_form.json
+++ b/example/example_form.json
@@ -193,6 +193,30 @@
       ]
     },
     {
+      "@id": "podtrida-fyzicka-osoby-s-velice-dlouhym-nazvem",
+      "label": "Podtřída fyzické osoby s velice dlouhým názvem",
+      "skos:broader": {
+        "@id": "fyzicka-osoba"
+      },
+      "owl:disjointWith": [
+        {
+          "@id": "pravnicka-osoba"
+        }
+      ]
+    },
+    {
+      "@id": "jeste-specifickejsi-podtrida-fyzicka-osoby-s-velice-dlouhym-nazvem",
+      "label": "Ještě specifickejší podtřída fyzické osoby s velice dlouhým názvem",
+      "skos:broader": {
+        "@id": "podtrida-fyzicka-osoby-s-velice-dlouhym-nazvem"
+      },
+      "owl:disjointWith": [
+        {
+          "@id": "pravnicka-osoba"
+        }
+      ]
+    },
+    {
       "@id": "fyzicka-osoba--hloupa",
       "label": "Fyzická osoba hloupá",
       "skos:broader": {
@@ -276,7 +300,9 @@
         "pravnicka-osoba",
         "fyzicka-osoba--nezletila",
         "fyzicka-osoba--chytra",
-        "fyzicka-osoba--hloupa"
+        "fyzicka-osoba--hloupa",
+        "podtrida-fyzicka-osoby-s-velice-dlouhym-nazvem",
+        "jeste-specifickejsi-podtrida-fyzicka-osoby-s-velice-dlouhym-nazvem"
       ],
       "has-non-selectable-value": [
         "fyzicka-osoba"

--- a/src/components/TypeQuestionAnswer.jsx
+++ b/src/components/TypeQuestionAnswer.jsx
@@ -13,7 +13,7 @@ import {
 import Constants from "../Constants";
 import SmartComponents from "../SmartComponents";
 import PropTypes from "prop-types";
-import {VirtualizedTreeSelect} from "intelligent-tree-select";
+import {IntelligentTreeSelect} from "intelligent-tree-select";
 import Utils from "../Utils";
 
 export default class TypeQuestionAnswer extends React.Component {
@@ -316,17 +316,18 @@ export default class TypeQuestionAnswer extends React.Component {
     }
 
     return (
-      <VirtualizedTreeSelect
+      <IntelligentTreeSelect
         value={selectedValue}
         valueKey="value"
         labelKey="label"
         childrenKey="children"
         options={Object.values(this.state.tree)}
-        optionHeight={80}
         expanded={true}
         closeOnSelect={this.state.singleSelect}
         onChange={this._onChange}
         multi={!this.state.singleSelect}
+        showSettings={false}
+        renderAsTree={false}
       />
     );
 

--- a/src/components/TypeQuestionAnswer.jsx
+++ b/src/components/TypeQuestionAnswer.jsx
@@ -327,7 +327,8 @@ export default class TypeQuestionAnswer extends React.Component {
         onChange={this._onChange}
         multi={!this.state.singleSelect}
         showSettings={false}
-        renderAsTree={false}
+        renderAsTree={true}
+        optionLeftOffset={5}
       />
     );
 
@@ -374,7 +375,6 @@ export default class TypeQuestionAnswer extends React.Component {
       </FormGroup>
     );
   }
-
 }
 
 TypeQuestionAnswer.contextType = ConfigurationContext;


### PR DESCRIPTION
This pull request refers to issue #7. 

Implicit height of tree was removed and option labels are shorten when too long and causing UI issues.