### PR TITLE
[#30] Simple question with tree typeahead introduced

### DIFF
--- a/src/SmartComponents.js
+++ b/src/SmartComponents.js
@@ -7,6 +7,7 @@ import NullQuestion from "./components/NullQuestion";
 import Utils from "./Utils";
 import SectionComponent from "./components/SectionComponent";
 import "./styles/components.css";
+import SimpleTreeTypeaheadQuestion from "./components/SimpleTreeTypeaheadQuestion.jsx";
 
 export default class SmartComponents {
   static componentCache = {};
@@ -40,6 +41,10 @@ export default class SmartComponents {
       {
         component: CompositeQuestion,
         mapRule: CompositeQuestion.mappingRule,
+      },
+      {
+        component: SimpleTreeTypeaheadQuestion,
+        mapRule: SimpleTreeTypeaheadQuestion.mappingRule,
       },
       {
         component: NullQuestion,

--- a/src/components/SimpleTreeTypeaheadAnswer.jsx
+++ b/src/components/SimpleTreeTypeaheadAnswer.jsx
@@ -1,0 +1,202 @@
+import React from "react";
+import { Form, FormGroup } from "react-bootstrap";
+import JsonLdUtils from "jsonld-utils";
+import {
+  QuestionStatic,
+  Constants as SConstants,
+  ConfigurationContext,
+  FormUtils,
+} from "@kbss-cvut/s-forms";
+import Constants from "../Constants";
+import { IntelligentTreeSelect } from "intelligent-tree-select";
+import Utils from "../Utils";
+import PropTypes from "prop-types";
+
+export default class SimpleTreeTypeaheadAnswer extends React.Component {
+  // Maybe add that the options are structured as tree - for example Constants.TREE_SELECT
+  static mappingRule = (q) => FormUtils.isTypeahead(q);
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      tree: {},
+      optionsList: [],
+      selected: {},
+    };
+  }
+
+  _handleChange = (value) => {
+    const change = { ...this.props.answer };
+
+    if (!value) {
+      this.setState({
+        selected: {},
+      });
+      change[SConstants.HAS_DATA_VALUE] = {
+        "@value": null,
+      };
+      this.props.onChange(this.props.index, change);
+      return;
+    }
+
+    change[SConstants.HAS_DATA_VALUE] = {
+      "@value": value["value"],
+    };
+
+    this.setState({
+      selected: value,
+    });
+
+    this.props.onChange(this.props.index, change);
+  };
+
+  _checkNonSelectableOptions(tree) {
+    const question = this.props.question;
+
+    for (let o of Object.values(tree)) {
+      if (
+        JsonLdUtils.hasValue(
+          question,
+          Constants.HAS_NON_SELECTABLE_VALUE,
+          o.value
+        )
+      ) {
+        o.isDisabled = true;
+      }
+    }
+  }
+
+  _isRegenerationNeeded(previousQuestion) {
+    if (!Object.values(this.state.tree).length) {
+      return true;
+    }
+    const question = this.props.question;
+    return !Utils.hasArraySameValues(
+      previousQuestion[SConstants.HAS_OPTION],
+      question[SConstants.HAS_OPTION]
+    );
+  }
+
+  _generateOptions() {
+    const question = this.props.question;
+    const possibleValues = question[SConstants.HAS_OPTION];
+    if (!possibleValues || !possibleValues.length) {
+      return [];
+    }
+
+    const options = {};
+    const relations = [];
+
+    for (let pValue of possibleValues) {
+      let label = JsonLdUtils.getLocalized(
+        pValue[SConstants.RDFS_LABEL],
+        this.context.options.intl
+      );
+
+      options[pValue["@id"]] = {
+        value: pValue["@id"],
+        label: label,
+        children: [],
+        disjoint: [],
+      };
+      for (let parent of Utils.asArray(pValue[Constants.BROADER])) {
+        relations.push({
+          type: "parent-child",
+          parent: parent["@id"],
+          child: pValue["@id"],
+        });
+      }
+    }
+
+    for (let relation of relations) {
+      if (relation.type === "parent-child") {
+        options[relation.parent]?.children.push(relation.child);
+      }
+    }
+
+    this._checkNonSelectableOptions(options);
+
+    this.setState({
+      tree: options,
+      optionsList: Object.values(options),
+    });
+  }
+
+  _renderSelect() {
+    if (!this.state.optionsList.length) {
+      return null;
+    }
+
+    return (
+      <IntelligentTreeSelect
+        value={this.state.selected}
+        className="react-select-simple-container"
+        classNamePrefix="react-select-simple"
+        valueKey="value"
+        labelKey="label"
+        childrenKey="children"
+        options={this.state.optionsList}
+        expanded={true}
+        closeMenuOnSelect={true}
+        onChange={this._handleChange}
+        multi={false}
+        showSettings={false}
+        renderAsTree={true}
+        optionLeftOffset={5}
+      />
+    );
+  }
+
+  componentDidMount() {
+    this._generateOptions();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this._isRegenerationNeeded(prevProps.question)) {
+      console.debug("regeneration needed");
+      this._generateOptions();
+    }
+  }
+
+  render() {
+    const question = this.props.question;
+    const options = this.context.options;
+    const onCommentChange = this.props.onCommentChange;
+    const showIcon = this.props.showIcon;
+
+    const label = JsonLdUtils.getLocalized(
+      this.props.question[SConstants.RDFS_LABEL],
+      this.context.options.intl
+    );
+
+    return (
+      <FormGroup>
+        <Form.Label>
+          <div className="question-header">
+            {label}
+            {QuestionStatic.renderIcons(
+              question,
+              options,
+              onCommentChange,
+              showIcon
+            )}
+          </div>
+        </Form.Label>
+        {this._renderSelect()}
+      </FormGroup>
+    );
+  }
+}
+
+SimpleTreeTypeaheadAnswer.contextType = ConfigurationContext;
+
+SimpleTreeTypeaheadAnswer.propTypes = {
+  index: PropTypes.number.isRequired,
+  answer: PropTypes.object.isRequired,
+  question: PropTypes.object.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onCommentChange: PropTypes.func.isRequired,
+  showIcon: PropTypes.bool.isRequired,
+  onSubChange: PropTypes.func.isRequired,
+};

--- a/src/components/SimpleTreeTypeaheadQuestion.jsx
+++ b/src/components/SimpleTreeTypeaheadQuestion.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import {
+  Answer,
+  ConfigurationContext,
+  FormUtils,
+  Question,
+} from "@kbss-cvut/s-forms";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import SimpleTreeTypeaheadAnswer from "./SimpleTreeTypeaheadAnswer";
+
+export default class SimpleTreeTypeaheadQuestion extends Question {
+  static mappingRule = (q) => FormUtils.isTypeahead(q);
+
+  constructor(props) {
+    super(props);
+  }
+
+  _renderAnswer(index, answer) {
+    const question = this.props.question;
+
+    let component = Answer;
+
+    if (SimpleTreeTypeaheadAnswer.mappingRule(question)) {
+      component = SimpleTreeTypeaheadAnswer;
+    }
+
+    return React.createElement(component, {
+      index: index,
+      answer: answer,
+      question: question,
+      onChange: this.handleAnswerChange,
+      onCommentChange: this.handleCommentChange,
+      showIcon: this.state.showIcon,
+      onSubChange: this.onSubQuestionChange,
+    });
+  }
+
+  renderAnswers() {
+    const question = this.props.question,
+      children = [],
+      answers = this._getAnswers();
+    let cls;
+    let isTextarea;
+
+    for (let i = 0, len = answers.length; i < len; i++) {
+      isTextarea =
+        FormUtils.isTextarea(question, FormUtils.resolveValue(answers[i])) ||
+        FormUtils.isSparqlInput(question) ||
+        FormUtils.isTurtleInput(question);
+      cls = classNames(
+        "answer",
+        Question._getQuestionCategoryClass(question),
+        Question.getEmphasizedOnRelevantClass(question)
+      );
+      children.push(
+        <div
+          key={"row-item-" + i}
+          className={cls}
+          id={question["@id"]}
+          onMouseEnter={this._onMouseEnterHandler}
+          onMouseLeave={this._onMouseLeaveHandler}
+        >
+          <div className="answer-content" style={this._getAnswerWidthStyle()}>
+            {this._renderAnswer(i, answers[i])}
+          </div>
+          {this._renderUnits()}
+          {this._renderPrefixes()}
+        </div>
+      );
+    }
+    return children;
+  }
+}
+
+SimpleTreeTypeaheadQuestion.contextType = ConfigurationContext;
+
+SimpleTreeTypeaheadQuestion.propTypes = {
+  index: PropTypes.number.isRequired,
+  answer: PropTypes.object.isRequired,
+  question: PropTypes.object.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onCommentChange: PropTypes.func.isRequired,
+};

--- a/src/stories/SimpleQuestionWithTreeTypeaheadAnswer.stories.tsx
+++ b/src/stories/SimpleQuestionWithTreeTypeaheadAnswer.stories.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import simpleTreeQuestion from "./assets/simple-single-tree-select.json";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import SmartComponents from "../s-forms-components";
+import SForms, { Constants, IntlContextProvider } from "@kbss-cvut/s-forms";
+
+import SimpleTreeTypeaheadAnswer from "../components/SimpleTreeTypeaheadAnswer";
+import possibleValues from "./assets/possibleValues.json";
+
+export default {
+  title: "Components/Simple question with tree typeahead answer",
+  component: SimpleTreeTypeaheadAnswer,
+} as ComponentMeta<typeof SimpleTreeTypeaheadAnswer>;
+
+const modalProps = {
+  onHide: () => {},
+  show: true,
+  title: "Title",
+};
+
+const options = {
+  i18n: {
+    "wizard.next": "Next",
+    "wizard.previous": "Previous",
+    "section.expand": "Expand",
+    "section.collapse": "Collapse",
+  },
+  intl: {
+    locale: "cs",
+  },
+  modalView: false,
+  modalProps,
+  horizontalWizardNav: false,
+  wizardStepButtons: true,
+  enableForwardSkip: true,
+  startingStep: 1,
+  users: [
+    { id: "http://fel.cvut.cz/people/max-chopart", label: "Max Chopart" },
+    {
+      id: "http://fel.cvut.cz/people/miroslav-blasko",
+      label: "Miroslav Blasko",
+    },
+  ],
+  currentUser: "http://fel.cvut.cz/people/max-chopart",
+  icons: [
+    {
+      id: Constants.ICONS.QUESTION_HELP,
+      behavior: Constants.ICON_BEHAVIOR.ENABLE,
+    },
+    {
+      id: Constants.ICONS.QUESTION_COMMENTS,
+      behavior: Constants.ICON_BEHAVIOR.ON_HOVER,
+    },
+    {
+      id: Constants.ICONS.QUESTION_LINK,
+      behavior: Constants.ICON_BEHAVIOR.ON_HOVER,
+    },
+  ],
+};
+
+const Template: ComponentStory<typeof SimpleTreeTypeaheadAnswer> = (args) => {
+  const fetchTypeAheadValues = (query) => {
+    return new Promise((resolve) =>
+      setTimeout(() => resolve(possibleValues), 1500)
+    );
+  };
+
+  return (
+    <IntlContextProvider locale={options.intl.locale}>
+      <SForms
+        options={options}
+        form={simpleTreeQuestion}
+        fetchTypeAheadValues={fetchTypeAheadValues}
+        componentMapRules={SmartComponents.getComponentMapping()}
+      />
+    </IntlContextProvider>
+  );
+};
+
+export const SingleSelect = Template.bind({});
+SingleSelect.args = {};

--- a/src/stories/assets/simple-single-tree-select.json
+++ b/src/stories/assets/simple-single-tree-select.json
@@ -1,0 +1,262 @@
+{ "@context": {
+  "doc": "http://onto.fel.cvut.cz/ontologies/documentation/",
+  "x": "https://x.com/x/",
+  "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+  "form": "http://onto.fel.cvut.cz/ontologies/form/",
+  "owl": "http://www.w3.org/2002/07/owl#",
+  "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  "xml": "http://www.w3.org/XML/1998/namespace",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
+  "skos": "http://www.w3.org/2004/02/skos/core#",
+  "label": {
+    "@id": "http://www.w3.org/2000/01/rdf-schema#label"
+  },
+  "has_data_value": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/documentation/has_data_value"
+  },
+  "has_answer": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/documentation/has_answer"
+  },
+  "has-answer-origin": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-answer-origin"
+  },
+  "has-possible-values-query": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-possible-values-query"
+  },
+  "has-possible-value": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-possible-value"
+  },
+  "has-layout-class": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form-layout/has-layout-class"
+  },
+  "has_related_question": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/documentation/has_related_question",
+    "@type": "@id"
+  },
+  "has-question-origin": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-question-origin",
+    "@type": "@id"
+  },
+  "is-relevant-if": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/is-relevant-if",
+    "@type": "@id"
+  },
+  "has-tested-question": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-tested-question",
+    "@type": "@id"
+  },
+  "has-sub-condition": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-sub-condition",
+    "@type": "@id"
+  },
+  "accepts-answer-value" : {
+    "@id" : "http://onto.fel.cvut.cz/ontologies/form/accepts-answer-value"
+  },
+  "has-importance" : {
+    "@id" : "http://onto.fel.cvut.cz/ontologies/form-template/has-importance",
+    "@type" : "@id"
+  },
+  "has-comment" : {
+    "@id" : "http://onto.fel.cvut.cz/ontologies/form/has-comment"
+  },
+  "has-timestamp" : {
+    "@id" : "http://onto.fel.cvut.cz/ontologies/form/has-timestamp"
+  },
+  "has-author" : {
+    "@id" : "http://onto.fel.cvut.cz/ontologies/form/has-author",
+    "@type" : "@id"
+  },
+  "has-comment-value" : {
+    "@id" : "http://onto.fel.cvut.cz/ontologies/form/has-comment-value"
+  },
+  "accepts-non-empty-answer-value": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/accepts-non-empty-answer-value",
+    "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+  },
+  "minInclusive": {
+    "@id": "http://www.w3.org/2001/XMLSchema#minInclusive"
+  },
+  "maxInclusive": {
+    "@id": "http://www.w3.org/2001/XMLSchema#maxInclusive"
+  },
+  "has-datatype": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-datatype",
+    "@type": "@id"
+  },
+  "has-preceding-question": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-preceding-question",
+    "@type": "@id"
+  },
+  "comment": {
+    "@id": "http://www.w3.org/2000/01/rdf-schema#comment"
+  },
+  "has-unit": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-unit"
+  },
+  "has-input-mask": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-input-mask"
+  },
+  "description": {
+    "@id": "http://purl.org/dc/elements/1.1/description"
+  },
+  "is-relevant-if_removed": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/is-relevant-if_removed",
+    "@type": "@id"
+  },
+  "requires-answer": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/requires-answer",
+    "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+  },
+  "accepts-validation-value": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/accepts-validation-value"
+  },
+  "imports": {
+    "@id": "http://www.w3.org/2002/07/owl#imports",
+    "@type": "@id"
+  },
+  "requires-answer-if": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/requires-answer-if",
+    "@type": "@id"
+  },
+  "has-media-content": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-media-content"
+  },
+  "has-composite-pattern": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-composite-pattern"
+  },
+  "has-pattern": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-pattern"
+  },
+  "has-composite-variables": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-composite-variables"
+  },
+  "show-advanced-question" : {
+    "@id" : "http://onto.fel.cvut.cz/ontologies/form/show-advanced-question"
+  },
+  "has-unit-of-measure-question": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-unit-of-measure-question"
+  },
+  "has-type-question": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-type-question"
+  },
+  "has-non-selectable-value": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-non-selectable-value"
+  },
+  "has-identifying-question": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form/has-identifying-question"
+  },
+  "initial-input-length": {
+    "@id": "http://onto.fel.cvut.cz/ontologies/form-layout/initial-input-length"
+  },
+  "source" : {
+    "@id" : "http://purl.org/dc/elements/1.1/source",
+    "@type" : "@id"
+  }
+},
+  "@graph": [
+    {
+      "@id": "pravnicka-osoba",
+      "label": "Právnická osoba"
+    },
+    {
+      "@id": "fyzicka-osoba",
+      "label": "Fyzická osoba",
+      "owl:disjointWith": [
+        {
+          "@id": "pravnicka-osoba"
+        }
+      ]
+    },
+    {
+      "@id": "fyzicka-osoba--nezletila",
+      "label": "Fyzická osoba nezletilá",
+      "skos:broader": {
+        "@id": "fyzicka-osoba"
+      },
+      "owl:disjointWith": [
+        {
+          "@id": "pravnicka-osoba"
+        }
+      ]
+    },
+    {
+      "@id": "fyzicka-osoba--chytra",
+      "label": "Fyzická osoba chytrá",
+      "skos:broader": {
+        "@id": "fyzicka-osoba"
+      },
+      "owl:disjointWith": [
+        {
+          "@id": "pravnicka-osoba"
+        }
+      ]
+    },
+    {
+      "@id": "podtrida-fyzicka-osoby-s-velice-dlouhym-nazvem",
+      "label": "Podtřída fyzické osoby s velice dlouhým názvem",
+      "skos:broader": {
+        "@id": "fyzicka-osoba"
+      },
+      "owl:disjointWith": [
+        {
+          "@id": "pravnicka-osoba"
+        }
+      ]
+    },
+    {
+      "@id": "jeste-specifickejsi-podtrida-fyzicka-osoby-s-velice-dlouhym-nazvem",
+      "label": "Ještě specifickejší podtřída fyzické osoby s velice dlouhým názvem",
+      "skos:broader": {
+        "@id": "podtrida-fyzicka-osoby-s-velice-dlouhym-nazvem"
+      },
+      "owl:disjointWith": [
+        {
+          "@id": "pravnicka-osoba"
+        }
+      ]
+    },
+    {
+      "@id": "fyzicka-osoba--hloupa",
+      "label": "Fyzická osoba hloupá",
+      "skos:broader": {
+        "@id": "fyzicka-osoba"
+      },
+      "owl:disjointWith": [
+        {
+          "@id": "pravnicka-osoba"
+        },
+        {
+          "@id": "fyzicka-osoba--chytra"
+        }
+      ]
+    },
+    {
+      "@id": "x:form-root",
+      "@type": "doc:question",
+      "has_related_question": [
+        "provozovatel-section-666"
+      ],
+      "has-layout-class": "form"
+    },
+    {
+      "@id": "provozovatel-section-666",
+      "@type": "doc:question",
+      "has-layout-class": [
+        "type-ahead"
+      ],
+      "has-possible-value": [
+        "fyzicka-osoba",
+        "pravnicka-osoba",
+        "fyzicka-osoba--nezletila",
+        "fyzicka-osoba--chytra",
+        "fyzicka-osoba--hloupa",
+        "podtrida-fyzicka-osoby-s-velice-dlouhym-nazvem",
+        "jeste-specifickejsi-podtrida-fyzicka-osoby-s-velice-dlouhym-nazvem"
+      ],
+      "has-non-selectable-value": [
+        "fyzicka-osoba"
+      ],
+      "label": "Má provozovatele"
+    }
+  ]
+}


### PR DESCRIPTION
I created `SimpleTreeTypeaheadQuestion` and `SimpleTreeTypeaheadAnswer` components. The first one handles whole question logic (lot of duplicates with `Question` from s-forms) and the second (answer) component handles the required tree select logic.

In the current state I get these warnings in storybook:
_The prop `onSubChange` is marked as required in `SimpleTreeTypeaheadAnswer`, but its value is `undefined`._

The same for props `showIcon` and `answer`. Currently, I render all components in this storybook as SForms´ children, so I am not sure what is missing in this case.

_Note:_
_Locally it behaves normally, but when I tried to click through some deployed netlify scenarios, I encountered weird behavior, even with this new components._